### PR TITLE
fix(ci): pin fflate to 0.8.2 to resolve attw crash in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,29 @@ jobs:
         run: pnpm build
 
       - name: Are The Types Wrong
+        shell: bash
         run: |
-          npm i -g @arethetypeswrong/cli
-          attw --pack packages/http
-          attw --pack packages/main-loader
-          attw --pack packages/mongodb
-          attw --pack packages/projection
+          set -euo pipefail
+          tmpdir=$(mktemp -d)
+          trap 'rm -rf "$tmpdir"' EXIT
+          cat > "$tmpdir/package.json" <<'EOF'
+          {
+            "dependencies": {
+              "@arethetypeswrong/cli": "0.18.1"
+            },
+            "pnpm": {
+              "overrides": {
+                "fflate": "0.8.2"
+              }
+            }
+          }
+          EOF
+          cd "$tmpdir"
+          pnpm install
+          pnpm exec attw --pack "$GITHUB_WORKSPACE/packages/http"
+          pnpm exec attw --pack "$GITHUB_WORKSPACE/packages/main-loader"
+          pnpm exec attw --pack "$GITHUB_WORKSPACE/packages/mongodb"
+          pnpm exec attw --pack "$GITHUB_WORKSPACE/packages/projection"
 
   lint:
     runs-on: macos-latest

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "overrides": {
       "cross-spawn@>=7.0.0 <7.0.5": ">=7.0.5",
       "fast-xml-parser@>=4.1.3 <4.5.4": ">=4.5.4",
+      "fflate": "0.8.2",
       "minimatch@^9": "9.0.9",
       "minimatch@^10": "10.2.4"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   fast-xml-parser@>=4.1.3 <4.5.4: '>=4.5.4'
+  fflate: 0.8.2
   minimatch@^9: 9.0.9
   minimatch@^10: 10.2.4
 


### PR DESCRIPTION
## Summary

Fixes #366 — CI build is failing.

## Root Cause

`fflate@0.8.3` changed the internal `Gunzip` streaming API behavior, breaking `@arethetypeswrong/core`'s tarball extraction logic. The `attw --pack` command now crashes with:

```
error while checking file:
Cannot read properties of undefined (reading 'filename')
```

See [arethetypeswrong/arethetypeswrong.github.io#258](https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258) and [PR #261](https://github.com/arethetypeswrong/arethetypeswrong.github.io/pull/261) (fix not yet released).

## Changes

1. **`package.json`**: Added `"fflate": "0.8.2"` to pnpm overrides to pin the transitive dependency to the working version.

2. **`.github/workflows/ci.yml`**: Changed the "Are The Types Wrong" step to install `@arethetypeswrong/cli` via a temporary pnpm project with its own `fflate` override. This ensures the pinned version is used during type checking, regardless of what npm would resolve.

## Validation

- Once `@arethetypeswrong/cli` releases a version with the upstream fix (PR #261), this workaround can be removed.
- The `fflate` override in root `package.json` serves as documentation and protection for any other tool that might use it.